### PR TITLE
Added IPv4 CIDR/Mask manifest Patch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,11 @@ options:
     default: "10.0.0.0/8"
     description: |
       IPv4 CIDR Range for Pods in cluster.
+  cluster-pool-ipv4-mask-size:
+    type: string
+    default: "24"
+    description: |
+      Mask size for each IPv4 podCIDR per node.
   enable-hubble:
     type: boolean
     default: false

--- a/config.yaml
+++ b/config.yaml
@@ -4,11 +4,21 @@ options:
     default: "10.0.0.0/8"
     description: |
       IPv4 CIDR Range for Pods in cluster.
+
+      The default value is obtained from upstream at the following link:
+        https://docs.cilium.io/en/stable/cmdref/cilium-operator/
+      For more information about configuring this value, please visit:
+        https://docs.cilium.io/en/v1.12/concepts/networking/ipam/cluster-pool/
   cluster-pool-ipv4-mask-size:
     type: string
     default: "24"
     description: |
       Mask size for each IPv4 podCIDR per node.
+
+      The default value is obtained from upstream at the following link:
+        https://docs.cilium.io/en/stable/cmdref/cilium-operator/
+      For more information about configuring this value, please visit:
+        https://docs.cilium.io/en/v1.12/concepts/networking/ipam/cluster-pool/
   enable-hubble:
     type: boolean
     default: false

--- a/src/cilium_manifests.py
+++ b/src/cilium_manifests.py
@@ -2,14 +2,31 @@
 
 from typing import Dict
 
-from ops.manifests import ConfigRegistry, ManifestLabel, Manifests
+from ops.manifests import ConfigRegistry, ManifestLabel, Manifests, Patch
+
+
+class SetIPv4CIDR(Patch):
+    """Configure IPv4 CIDR and Node Mask."""
+
+    def __call__(self, obj) -> None:
+        """Update ConfigMap IPv4 CIDR and Mask size."""
+        if not (obj.kind == "ConfigMap" and obj.metadata.name == "cilium-config"):
+            return
+
+        data = obj.data
+        data["cluster-pool-ipv4-cidr"] = self.manifests.config["cluster-pool-ipv4-cidr"]
+        data["cluster-pool-ipv4-mask-size"] = self.manifests.config["cluster-pool-ipv4-mask-size"]
 
 
 class CiliumManifests(Manifests):
     """Deployment manager for the Cilium charm."""
 
     def __init__(self, charm, charm_config):
-        manipulations = [ManifestLabel(self), ConfigRegistry(self)]
+        manipulations = [
+            ConfigRegistry(self),
+            ManifestLabel(self),
+            SetIPv4CIDR(self),
+        ]
 
         super().__init__("cilium", charm.model, "upstream/cilium", manipulations)
         self.charm_config = charm_config


### PR DESCRIPTION
## Changes
The option to configure the IPv4 CIDR and Mask Size has been added to the Cilium charm. Changing these configuration values did not affect the values for the `cilium` container.
