### PR TITLE
Fix `send-remote-write` events

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -26,7 +26,7 @@ jobs:
     needs: 
       - lint-unit
     runs-on: self-hosted
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ops >= 1.5.0
 lightkube
 ops.manifest >= 1.1.0
 Jinja2
-pydantic
+pydantic==1.*

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -352,8 +352,7 @@ async def expected_dashboard_titles():
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.usefixtures("cos_lite_installed")
-async def related_grafana(ops_test, cos_lb_model):
+async def related_grafana(ops_test, cos_lb_model, cos_lite_installed):
     cos_model, k8s_alias = cos_lb_model
     model_owner = untag("user-", cos_model.info.owner_tag)
     cos_model_name = cos_model.name
@@ -375,8 +374,8 @@ async def related_grafana(ops_test, cos_lb_model):
         await ops_test.model.wait_for_idle(status="active")
     with ops_test.model_context(k8s_alias) as model:
         log.info("Removing Grafana Offer...")
-        await ops_test.model.remove_offer("grafana-dashboard", force=True)
-        await ops_test.model.wait_for_idle(status="active")
+        await model.remove_offer("grafana-dashboards", force=True)
+        await model.wait_for_idle(status="active")
 
 
 @pytest.fixture(scope="module")
@@ -398,8 +397,7 @@ async def expected_prometheus_metrics():
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.usefixtures("cos_lite_installed")
-async def related_prometheus(ops_test, cos_lb_model):
+async def related_prometheus(ops_test, cos_lb_model, cos_lite_installed):
     cos_model, k8s_alias = cos_lb_model
     model_owner = untag("user-", cos_model.info.owner_tag)
     cos_model_name = cos_model.name
@@ -433,5 +431,5 @@ async def related_prometheus(ops_test, cos_lb_model):
 
     with ops_test.model_context(k8s_alias) as model:
         log.info("Removing Prometheus Offer...")
-        await ops_test.model.remove_offer("receive-remote-write", force=True)
-        await ops_test.model.wait_for_idle(status="active")
+        await model.remove_offer("prometheus-receive-remote-write", force=True)
+        await model.wait_for_idle(status="active")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -280,7 +280,7 @@ async def cos_lb_model(k8s_cloud, ops_test, metallb_installed):
 
     yield model, model_alias
 
-    timeout = 5 * 60
+    timeout = 10 * 60
     await ops_test.forget_model(model_alias, timeout=timeout, allow_failure=False)
 
     async def model_removed():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -374,7 +374,7 @@ async def related_grafana(ops_test, cos_lb_model, cos_lite_installed):
         await ops_test.model.wait_for_idle(status="active")
     with ops_test.model_context(k8s_alias) as model:
         log.info("Removing Grafana Offer...")
-        await model.remove_offer("grafana-dashboards", force=True)
+        await model.remove_offer(f"{model.name}.grafana-dashboards", force=True)
         await model.wait_for_idle(status="active")
 
 
@@ -397,7 +397,7 @@ async def expected_prometheus_metrics():
 
 
 @pytest.fixture(scope="module")
-async def related_prometheus(ops_test, cos_lb_model, cos_lite_installed):
+async def related_prometheus(ops_test: OpsTest, cos_lb_model, cos_lite_installed):
     cos_model, k8s_alias = cos_lb_model
     model_owner = untag("user-", cos_model.info.owner_tag)
     cos_model_name = cos_model.name
@@ -431,5 +431,5 @@ async def related_prometheus(ops_test, cos_lb_model, cos_lite_installed):
 
     with ops_test.model_context(k8s_alias) as model:
         log.info("Removing Prometheus Offer...")
-        await model.remove_offer("prometheus-receive-remote-write", force=True)
+        await model.remove_offer(f"{model.name}.prometheus-receive-remote-write", force=True)
         await model.wait_for_idle(status="active")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@ import unittest.mock as mock
 
 import ops.testing
 import pytest
+from lightkube.core.exceptions import ApiError
 from ops.testing import Harness
 
 from charm import CiliumCharm
@@ -56,3 +57,14 @@ def charm(request, harness: Harness[CiliumCharm]):
 def lk_client():
     with mock.patch("ops.manifests.manifest.Client", autospec=True) as mock_lightkube:
         yield mock_lightkube.return_value
+
+
+@pytest.fixture()
+def api_error_klass():
+    class TestApiError(ApiError):
+        status = mock.MagicMock()
+
+        def __init__(self):
+            pass
+
+    yield TestApiError


### PR DESCRIPTION
## Summary
Cilium charm units enter in `error` state when the `kubeconfig` file is not yet available to the unit.

## Changes
- Handle both the `changed` and `departed` events so that the execution can occur after the `kubeconfig` file becomes available in the unit.
- Defer events in case there are any issues with the process.

### Related Issues
[LP#2025162](https://bugs.launchpad.net/charm-cilium/+bug/2025162)