### PR TITLE
Support Geneve protocol

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,8 +54,13 @@ options:
   release:
     description: Version of Cilium to deploy
     type: string
-  use-geneve-protocol:
-    type: boolean 
-    default: false
+  tunnel-protocol:
+    type: string 
+    default: vxlan
     description: | 
-      Enable geneve UDP-based tunnel encapsulation protocol instead of vxlan
+      Type of Cilium tunnel encapsulation protocol.
+      The default encapsulation protocol is vxlan. 
+      
+      valid options are:
+          * vxlan
+          * geneve

--- a/config.yaml
+++ b/config.yaml
@@ -54,3 +54,8 @@ options:
   release:
     description: Version of Cilium to deploy
     type: string
+  use-geneve-protocol:
+    type: boolean 
+    default: false
+    description: | 
+      Enable geneve UDP-based tunnel encapsulation protocol instead of vxlan

--- a/src/charm.py
+++ b/src/charm.py
@@ -154,8 +154,10 @@ class CiliumCharm(CharmBase):
                 event, "Waiting to retry Cilium configuration.", exc_info=True
             )
         except (ValidationError, ValueError) as e:
-            self.unit.status = BlockedStatus("Invalid Cilium configuration")
-            log.exception(e.errors())
+            errors = e.errors()
+            key = errors[0].get("msg", "Unknown") if errors else "Unknown"
+            self.unit.status = BlockedStatus(f"Invalid Cilium configuration: {key}")
+            log.exception(errors)
             return
         
     def _configure_cni_relation(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -278,8 +278,9 @@ class CiliumCharm(CharmBase):
     def _on_config_changed(self, event):
         self._configure_cni_relation()
         self._configure_cilium(event)
-        self._install_cli_resources()
-        self._on_port_forward_hubble()
+        if self.stored.cilium_configured:
+            self._install_cli_resources()
+            self._on_port_forward_hubble()
         self._set_active_status()
 
     def _on_cni_relation_changed(self, event):

--- a/src/cilium_manifests.py
+++ b/src/cilium_manifests.py
@@ -142,11 +142,13 @@ class PatchTunnelProtocol(Patch):
         if not (obj.kind == "ConfigMap" and obj.metadata.name == "cilium-config"):
             return
 
-        if not self.manifests.config["use-geneve-protocol"]:
+        if not self.manifests.config["tunnel-protocol"]:
             return
 
+        log.info(f"Patching cilium tunnel protocol: {self.manifests.config['tunnel-protocol']}")
+
         data = obj.data
-        data["tunnel-protocol"] = "geneve"
+        data["tunnel-protocol"] = self.manifests.config["tunnel-protocol"]
 
 
 class CiliumManifests(Manifests):

--- a/src/cilium_manifests.py
+++ b/src/cilium_manifests.py
@@ -138,6 +138,7 @@ class PatchTunnelProtocol(Patch):
     """Configure Network tunnel Encapsulation protocol."""
 
     def __call__(self, obj) -> None:
+        """Update Cilium tunnel encapsulation protocol."""
         if not (obj.kind == "ConfigMap" and obj.metadata.name == "cilium-config"):
             return
 
@@ -146,6 +147,7 @@ class PatchTunnelProtocol(Patch):
 
         data = obj.data
         data["tunnel-protocol"] = "geneve"
+
 
 class CiliumManifests(Manifests):
     """Deployment manager for the Cilium charm."""

--- a/src/cilium_manifests.py
+++ b/src/cilium_manifests.py
@@ -134,6 +134,19 @@ class SetIPv4CIDR(Patch):
         data["cluster-pool-ipv4-mask-size"] = self.manifests.config["cluster-pool-ipv4-mask-size"]
 
 
+class PatchTunnelProtocol(Patch):
+    """Configure Network tunnel Encapsulation protocol."""
+
+    def __call__(self, obj) -> None:
+        if not (obj.kind == "ConfigMap" and obj.metadata.name == "cilium-config"):
+            return
+
+        if not self.manifests.config["use-geneve-protocol"]:
+            return
+
+        data = obj.data
+        data["tunnel-protocol"] = "geneve"
+
 class CiliumManifests(Manifests):
     """Deployment manager for the Cilium charm."""
 
@@ -148,6 +161,7 @@ class CiliumManifests(Manifests):
             PatchPrometheusConfigMap(self),
             PatchHubbleMetricsConfigMap(self),
             SetIPv4CIDR(self),
+            PatchTunnelProtocol(self),
         ]
 
         super().__init__("cilium", charm.model, "upstream/cilium", manipulations)

--- a/src/cilium_validators.py
+++ b/src/cilium_validators.py
@@ -1,0 +1,21 @@
+"""Validators for Cilium configuration values."""
+
+from pydantic import BaseModel, validator
+
+
+class TunnelEncapsulationProtocol(BaseModel):
+    """Class to validate the value of the Cilium tunnel encapsulation protocol provided by the user."""
+
+    tunnel_protocol: str
+
+    @validator("tunnel_protocol")
+    def validate_tunnel_protocol(cls, v):
+        """Check that the value provided as tunnel protocol are in the allowed values."""
+        allowed_values = {
+            "vxlan",
+            "geneve",
+        }
+
+        if v not in allowed_values:
+            raise ValueError(f"{v} is not an allowed Cilium tunnel encapsulation protocol.")
+        return v

--- a/tests/integration/test_cilium_charm.py
+++ b/tests/integration/test_cilium_charm.py
@@ -87,7 +87,7 @@ async def test_cilium_blocked(ops_test: OpsTest):
 async def test_cilium_geneve_protocol(ops_test: OpsTest):
     log.info("Switching to Geneve protocol in Cilium...")
     cilium_app = ops_test.model.applications["cilium"]
-    await cilium_app.set_config({"use-geneve-protocol": "true"})
+    await cilium_app.set_config({"tunnel-protocol": "geneve"})
     async with ops_test.fast_forward("30s"):
         await ops_test.model.wait_for_idle(status="active", timeout=TEN_MINUTES)
 
@@ -174,4 +174,3 @@ async def test_prometheus(ops_test, traefik_ingress):
     await asyncio.sleep(120)
     metrics = await prometheus.get_metrics()
     assert any(m.startswith("cilium_") for m in metrics), "No cilium metrics found in Prometheus"
-    

--- a/tests/integration/test_cilium_charm.py
+++ b/tests/integration/test_cilium_charm.py
@@ -174,4 +174,4 @@ async def test_prometheus(ops_test, traefik_ingress):
     await asyncio.sleep(120)
     metrics = await prometheus.get_metrics()
     assert any(m.startswith("cilium_") for m in metrics), "No cilium metrics found in Prometheus"
-
+    

--- a/tests/integration/test_cilium_charm.py
+++ b/tests/integration/test_cilium_charm.py
@@ -86,7 +86,7 @@ async def test_cilium_blocked(ops_test: OpsTest):
 
 async def test_cilium_tunnel_protocol(ops_test: OpsTest):
     cilium_app = ops_test.model.applications["cilium"]
-    
+
     log.info("Switching to gre protocol in Cilium...")
     await cilium_app.set_config({"tunnel-protocol": "gre"})
     async with ops_test.fast_forward("30s"):
@@ -97,6 +97,7 @@ async def test_cilium_tunnel_protocol(ops_test: OpsTest):
     await cilium_app.set_config({"tunnel-protocol": "geneve"})
     async with ops_test.fast_forward("30s"):
         await ops_test.model.wait_for_idle(status="active", timeout=TEN_MINUTES)
+    assert cilium_app.status == "active", "Cilium should be active"
 
 
 async def test_cli_resources(ops_test: OpsTest):

--- a/tests/integration/test_cilium_charm.py
+++ b/tests/integration/test_cilium_charm.py
@@ -84,9 +84,16 @@ async def test_cilium_blocked(ops_test: OpsTest):
     assert cilium_app.status == "active", "Cilium should be active"
 
 
-async def test_cilium_geneve_protocol(ops_test: OpsTest):
-    log.info("Switching to Geneve protocol in Cilium...")
+async def test_cilium_tunnel_protocol(ops_test: OpsTest):
     cilium_app = ops_test.model.applications["cilium"]
+    
+    log.info("Switching to gre protocol in Cilium...")
+    await cilium_app.set_config({"tunnel-protocol": "gre"})
+    async with ops_test.fast_forward("30s"):
+        await ops_test.model.wait_for_idle(timeout=TEN_MINUTES)
+    assert cilium_app.status == "blocked", "Cilium should be blocked"
+    
+    log.info("Switching to Geneve protocol in Cilium...")
     await cilium_app.set_config({"tunnel-protocol": "geneve"})
     async with ops_test.fast_forward("30s"):
         await ops_test.model.wait_for_idle(status="active", timeout=TEN_MINUTES)


### PR DESCRIPTION
This PR suggests the support for the Geneve tunnel encapsulation protocol. A few considerations:

1) I favored adding the option as a boolean to switch between `vxlan` and `geneve`. We could have made it a string option to be set by the user but then we would need to have a way for validation and also address whether we want to support the `None` option, which is valid but disables the tunnel encapsulation altogether. 

2) The integration test switches the cilium encapsulation to `geneve` at the start of the test and doesn't change it back to `vxlan` for subsequent test cases. I made it this way so we can actually be sure the `geneve` is actually working without repeating the steps, but the downside is that if there is a problem with `geneve`, it will be leaked and the results of the other tests are also affected. If you think it's not a good idea we can discuss the alternatives.