### PR TITLE
Add enable-session-affinity config to config-map

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,11 +34,16 @@ options:
     default: ""
     description: |
       Expose Prometheus metrics for the Hubble Observability components.
-      
+
       The configuration value should include the desired values to scrape from
       Hubble in a space separated list.
       For more information about configuring this value, please visit:
         https://docs.cilium.io/en/latest/observability/metrics/#hubble-exported-metrics
+  enable-session-affinity:
+    type: boolean
+    default: false
+    description: |
+      Enable session affinity for Cilium.
   image-registry:
     default: rocks.canonical.com:443/cdk
     type: string
@@ -55,12 +60,12 @@ options:
     description: Version of Cilium to deploy
     type: string
   tunnel-protocol:
-    type: string 
+    type: string
     default: vxlan
-    description: | 
+    description: |
       Type of Cilium tunnel encapsulation protocol.
-      The default encapsulation protocol is vxlan. 
-      
+      The default encapsulation protocol is vxlan.
+
       valid options are:
           * vxlan
           * geneve
@@ -71,5 +76,5 @@ options:
       Default ports are assigned based on the `tunnel-protocol` config option:
         - VXLAN: port 8472
         - Geneve: port 6081
-        
+
       If set, the user configured port will be used over the default.

--- a/config.yaml
+++ b/config.yaml
@@ -44,6 +44,9 @@ options:
     default: false
     description: |
       Enable session affinity for Cilium.
+
+      For more information about configuring this value, please visit:
+         https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#id2
   image-registry:
     default: rocks.canonical.com:443/cdk
     type: string

--- a/src/cilium_manifests.py
+++ b/src/cilium_manifests.py
@@ -121,9 +121,9 @@ class PatchCiliumConfig(Patch):
             data.update(values)
             log.info("Patching Hubble metrics [%s]: %s", metrics, values)
 
-        session_affinity = self.manifests.config.get("enable-session-affinity")
-        log.info("Patching cilium session-affinity: %s", session_affinity)
-        data["enable-session-affinity"] = session_affinity
+        if session_affinity := self.manifests.config["enable-session-affinity"]:
+            log.info("Patching cilium session-affinity: %s", session_affinity)
+            data["enable-session-affinity"] = "true"
 
 
 class CiliumManifests(Manifests):


### PR DESCRIPTION
[LP#2108567](https://bugs.launchpad.net/charm-cilium/+bug/2108567)

### Overview
* Adding session-affinity configuration


### Details
* creates a new config `enable-session-affinity` enabled by default to "false"
* combines all the patchers of the config-map into a single class