### PR TITLE
Catching too narrow an exception 'ConnectError', use broader 'HTTPError'

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -18,7 +18,7 @@ from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.prometheus_k8s.v0.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
 )
-from httpx import ConnectError, HTTPError
+from httpx import HTTPError
 from jinja2 import Environment, FileSystemLoader
 from lightkube import Client, codecs
 from lightkube.core.exceptions import ApiError
@@ -157,7 +157,7 @@ class CiliumCharm(CharmBase):
             with self.cilium_manifests.restart_if_exists():
                 self.cilium_manifests.apply_manifests()
             self.stored.cilium_configured = True
-        except (ManifestClientError, ConnectError):
+        except (ManifestClientError, ApiError, HTTPError):
             log.exception("Encountered error configuring cilium")
             return self._ops_wait_for(
                 event, "Waiting to retry Cilium configuration.", exc_info=True
@@ -183,7 +183,7 @@ class CiliumCharm(CharmBase):
                 self._configure_hubble_metrics()
                 self.hubble_manifests.apply_manifests()
                 self.stored.hubble_configured = True
-            except (ManifestClientError, ConnectError):
+            except (ManifestClientError, ApiError, HTTPError):
                 return self._ops_wait_for(
                     event, "Waiting to retry Hubble configuration.", exc_info=True
                 )
@@ -199,7 +199,7 @@ class CiliumCharm(CharmBase):
                 self.unit.status = MaintenanceStatus("Removing Hubble resources.")
                 self.hubble_manifests.delete_manifests()
                 self.stored.hubble_configured = False
-            except (ManifestClientError, ConnectError):
+            except (ManifestClientError, ApiError, HTTPError):
                 return self._ops_wait_for(event, "Waiting to retry Hubble removal.", exc_info=True)
 
     def _configure_hubble_metrics(self):

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -4,6 +4,10 @@ applications:
   kubernetes-control-plane:
     options:
       allow-privileged: "true"
+      sysctl: &sysctl "{net.ipv4.conf.all.forwarding: 1, net.ipv4.conf.all.rp_filter: 0, net.ipv4.neigh.default.gc_thresh1: 128, net.ipv4.neigh.default.gc_thresh2: 28672, net.ipv4.neigh.default.gc_thresh3: 32768, net.ipv6.neigh.default.gc_thresh1: 128, net.ipv6.neigh.default.gc_thresh2: 28672, net.ipv6.neigh.default.gc_thresh3: 32768, fs.inotify.max_user_instances: 8192, fs.inotify.max_user_watches: 1048576, kernel.panic: 10, kernel.panic_on_oops: 1, vm.overcommit_memory: 1}"
+  kubernetes-worker:
+    options:
+      sysctl: *sysctl
   cilium:
     charm: {{charm}}
     options:

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -4,10 +4,6 @@ applications:
   kubernetes-control-plane:
     options:
       allow-privileged: "true"
-      sysctl: &sysctl "{net.ipv4.conf.all.forwarding: 1, net.ipv4.conf.all.rp_filter: 0, net.ipv4.neigh.default.gc_thresh1: 128, net.ipv4.neigh.default.gc_thresh2: 28672, net.ipv4.neigh.default.gc_thresh3: 32768, net.ipv6.neigh.default.gc_thresh1: 128, net.ipv6.neigh.default.gc_thresh2: 28672, net.ipv6.neigh.default.gc_thresh3: 32768, fs.inotify.max_user_instances: 8192, fs.inotify.max_user_watches: 1048576, kernel.panic: 10, kernel.panic_on_oops: 1, vm.overcommit_memory: 1}"
-  kubernetes-worker:
-    options:
-      sysctl: *sysctl
   cilium:
     charm: {{charm}}
     options:

--- a/tests/data/sysctl-overlay.yaml
+++ b/tests/data/sysctl-overlay.yaml
@@ -1,0 +1,8 @@
+description: Sysctl settings for Kubernetes nodes
+applications:
+  kubernetes-control-plane:
+    options:
+      sysctl: &sysctl "{net.ipv4.conf.all.forwarding: 1, net.ipv4.conf.all.rp_filter: 0, net.ipv4.neigh.default.gc_thresh1: 128, net.ipv4.neigh.default.gc_thresh2: 28672, net.ipv4.neigh.default.gc_thresh3: 32768, net.ipv6.neigh.default.gc_thresh1: 128, net.ipv6.neigh.default.gc_thresh2: 28672, net.ipv6.neigh.default.gc_thresh3: 32768, fs.inotify.max_user_instances: 8192, fs.inotify.max_user_watches: 1048576, kernel.panic: 10, kernel.panic_on_oops: 1, vm.overcommit_memory: 1}"
+  kubernetes-worker:
+    options:
+      sysctl: *sysctl

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,11 +38,22 @@ def pytest_addoption(parser):
         default="1.16.10",
         help="Cilium version to deploy",
     )
+    parser.addoption(
+        "--sysctl-post-deploy",
+        action="store_true",
+        default=False,
+        help="Apply sysctl settings after deploying test model",
+    )
 
 
 @pytest.fixture
 def version(request):
     return request.config.getoption("--cilium-version")
+
+
+@pytest.fixture()
+def sysctl_post_deploy(request):
+    return request.config.getoption("--sysctl-post-deploy")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### ISSUE# [LP#2122155](https://bugs.launchpad.net/charm-cilium/+bug/2122155)

### Overview
* catching too narrow of an exception doesn't handle cases where the API server is temporarily down or unable to make a connection.  Using a broader exception is a cleaner approach for retrying

### Details
* provides a test switch to apply sysctl params after the model is deployed (defaults to false)

