### PR TITLE
Update image-registry default to ghcr.io/canonical/cdk

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ options:
       For more information about configuring this value, please visit:
          https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#id2
   image-registry:
-    default: rocks.canonical.com:443/cdk
+    default: ghcr.io/canonical/cdk
     type: string
     description: |
       Source registry of Cilium CNI images.


### PR DESCRIPTION
`rocks.canonical.com` is being retired. This PR updates the image registry
references from the legacy registry to the new GitHub Container Registry.

**Changes:**
- `rocks.canonical.com:443/cdk` → `ghcr.io/canonical/cdk`
- `rocks.canonical.com/cdk` → `ghcr.io/canonical/cdk`
